### PR TITLE
Add markup option to yard opts for consistency and confusion reduction

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -29,10 +29,13 @@ You'll probably want to add these to your .gitignore as well
 So you'll have to re-genenarte your API on every machine. This should encourage more up to dateness
 
 ## Execution
-It is recommended that you use a .yardopts file
+It is recommended that you use a .yardopts file. The sample below
+assumes you are using Markdown in your YARD, as does the sample
+documentation.
 
 	--title "My API Documentation"
 	--plugin restful
+  --markup markdown
 	--readme API_README
 	--output-dir ./public/api
 	app/models/**/*.rb

--- a/README.markdown
+++ b/README.markdown
@@ -35,7 +35,7 @@ documentation.
 
 	--title "My API Documentation"
 	--plugin restful
-  --markup markdown
+        --markup markdown
 	--readme API_README
 	--output-dir ./public/api
 	app/models/**/*.rb


### PR DESCRIPTION
Make the `.yardopts` file match the documentation samples by including a markup option to use markdown. 

The author alludes to the need for the `redcarpet` gem, which isn't actually used by YARD unless 
```
--markup markdown`
```
 is in the `./yardopts` file